### PR TITLE
Feat/linter use stylelint api directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gulp.task('lint-css', function lintCssTask() {
   return gulp
     .src('src/**/*.css')
     .pipe(gulpStylelint({
-      stylelint: {
+      config: {
         extends: 'stylelint-config-suitcss'
       },
       reporters: [
@@ -73,7 +73,7 @@ gulp.task('lint-css', function lintCssTask() {
 });
 ```
 
-#### `stylelint` [Object]
+#### `config` [Object]
 
 See [stylelint configuration](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md) options. When omitted, the configuration is taken from the .stylelintrc file.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/olegskl/gulp-stylelint",
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "postcss": "^5.0.14",
     "stylelint": "^4.0.0",
     "through2": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,7 @@
  * @module gulp-stylelint
  */
 
-import postcss from 'postcss';
-import stylelint from 'stylelint';
+import {lint} from 'stylelint';
 import gulpUtil from 'gulp-util';
 import through from 'through2';
 
@@ -24,7 +23,6 @@ const pluginName = 'gulp-stylelint';
  */
 export default function gulpStylelint(options = {}) {
   const promiseList = [];
-  const postcssProcessor = postcss([stylelint(options.stylelint)]);
 
   /**
    * Launches processing of a given file and adds it to the promise list.
@@ -47,10 +45,11 @@ export default function gulpStylelint(options = {}) {
       return done(new gulpUtil.PluginError(pluginName, 'Streaming not supported'));
     }
 
-    const fileContents = file.contents.toString();
-    const promise = postcssProcessor.process(fileContents, {from: file.path});
-
-    promiseList.push(promise);
+    promiseList.push(lint({
+      code: file.contents.toString(),
+      codeFilename: file.path,
+      config: options.stylelint
+    }));
 
     done(null, file);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -45,11 +45,28 @@ export default function gulpStylelint(options = {}) {
       return done(new gulpUtil.PluginError(pluginName, 'Streaming not supported'));
     }
 
-    promiseList.push(lint({
+    // Override code and codeFilename with our own data:
+    const linterOptions = Object.assign({}, options, {
       code: file.contents.toString(),
-      codeFilename: file.path,
-      config: options.stylelint
-    }));
+      codeFilename: file.path
+    });
+
+    // Backwards compatibility with 0.2.0:
+    if (linterOptions.hasOwnProperty('stylelint') &&
+        !linterOptions.hasOwnProperty('config')) {
+      linterOptions.config = linterOptions.stylelint;
+      delete linterOptions.stylelint;
+    }
+
+    // Delete the options that cannot be used here:
+    delete linterOptions.files;
+    delete linterOptions.formatter;
+
+    // Delete the options not related to stylelint:
+    delete linterOptions.reporters;
+    delete linterOptions.debug;
+
+    promiseList.push(lint(linterOptions));
 
     done(null, file);
   }


### PR DESCRIPTION
Related to #4. Uses Stylelint API directly, not as a PostCSS plugin.