### PR TITLE
fix(plugin): replace Object.assign by deep-extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/olegskl/gulp-stylelint",
   "dependencies": {
     "chalk": "^1.1.3",
+    "deep-extend": "^0.4.1",
     "gulp-util": "^3.0.7",
     "mkdirp": "^0.5.1",
     "promise": "^7.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {lint} from 'stylelint';
 import gulpUtil from 'gulp-util';
 import through from 'through2';
 import Promise from 'promise';
+import deepExtend from 'deep-extend';
 import * as formatters from 'stylelint/dist/formatters';
 import reporterFactory from './reporter-factory';
 
@@ -43,7 +44,7 @@ module.exports = function gulpStylelint(options = {}) {
    * Lint options for stylelint's `lint` function.
    * @type Object
    */
-  const lintOptions = Object.assign({
+  const lintOptions = deepExtend({
     failAfterError: true,
     debug: false
   }, options);
@@ -80,7 +81,7 @@ module.exports = function gulpStylelint(options = {}) {
       return;
     }
 
-    const localLintOptions = Object.assign({}, lintOptions, {
+    const localLintOptions = deepExtend({}, lintOptions, {
       code: file.contents.toString(),
       codeFilename: file.path
     });


### PR DESCRIPTION
 - Object.assign is not available on Node 0.12
 - ensures that objects are cloned deep, not shallow

Related to #11.