### PR TITLE
chore(package): drop babel-tape-runner dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint src/**/*.js",
-    "test": "babel-tape-runner test/*.spec.js",
+    "test": "tape -r babel-register test/*.spec.js",
     "transpile": "babel src --out-dir dist",
     "prepublish": "npm run lint && npm test && npm run transpile"
   },
@@ -38,7 +38,7 @@
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.6",
     "babel-preset-es2015": "^6.6.0",
-    "babel-tape-runner": "^2.0.1",
+    "babel-register": "^6.7.2",
     "eslint": "^2.7.0",
     "eslint-config-meetic": "^2.0.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Using vanilla tape is simpler and safer because it doesn't add polyfills.

Related to #11.