### PR TITLE
chore(package): update stylelint dependency to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "^3.0.7",
     "mkdirp": "^0.5.1",
     "promise": "^7.1.1",
-    "stylelint": "^5.4.0",
+    "stylelint": "^6.0.3",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`stylelint` was [updated to 6.0.0](https://github.com/stylelint/stylelint/releases/tag/6.0.0) yesterday.
Please review this.