### PR TITLE
chore(package): update stylelint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "^3.0.7",
     "mkdirp": "^0.5.1",
     "promise": "^7.1.1",
-    "stylelint": "^6.0.3",
+    "stylelint": "^6.2.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update stylelint to version 6.2.1 which includes great improvements especially when linting sass files.