### PR TITLE
chore(travis): drop node 0.12, add 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
   - 5
   - 4
-  - 0.12


### PR DESCRIPTION
Stylelint 7.x no longer supports node 0.12, so neither should we.