### PR TITLE
Support sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "chalk": "^1.1.3",
     "deep-extend": "^0.4.1",
     "gulp-util": "^3.0.7",
+    "lodash": "^4.16.2",
     "mkdirp": "^0.5.1",
     "promise": "^7.1.1",
+    "source-map": "^0.5.6",
     "stylelint": "^7.3.1",
     "through2": "^2.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import Promise from 'promise';
 import deepExtend from 'deep-extend';
 import * as formatters from 'stylelint/dist/formatters';
 import reporterFactory from './reporter-factory';
+import {applySourcemap} from './sourcemap';
 
 /**
  * Name of this plugin for reporting purposes.
@@ -93,7 +94,13 @@ module.exports = function gulpStylelint(options) {
       codeFilename: file.path
     });
 
-    lintPromiseList.push(lint(localLintOptions));
+    const sourceMap = file.sourceMap;
+    const promise = lint(localLintOptions).then(lintResult =>
+      new Promise(resolve => {
+        resolve(applySourcemap(lintResult, sourceMap));
+      })
+    );
+    lintPromiseList.push(promise);
 
     done(null, file);
   }

--- a/src/sourcemap.js
+++ b/src/sourcemap.js
@@ -1,0 +1,58 @@
+/**
+ * Gulp stylelint sourcemap.
+ * @module gulp-stylelint/sourcemap
+ */
+
+import {findIndex, flatMap} from 'lodash';
+import {SourceMapConsumer} from 'source-map';
+
+/**
+ * @param{Object} lintResult - Result of StyleLint.
+ * @param{Function} originalPositionFor - A function to translate position
+ * @return {Object} Same as lintResult structure.
+ */
+function _applySourcemap(lintResult, originalPositionFor) { // eslint-disable-line
+  const results = flatMap(lintResult.results, result => {
+    return result.warnings.map(warn => {
+      const origPos = originalPositionFor(warn);
+      return Object.assign({}, warn, origPos);
+    }).reduce((sum, warn) => {
+      const source = warn.source || result.source;
+      delete warn.source;
+      const idx = findIndex(sum, r => r.source === source);
+      if (idx === -1) {
+        const ret = Object.assign({}, result, {
+          source,
+          warnings: [warn]
+        });
+        sum.push(ret);
+      } else {
+        sum[idx].warnings.push(warn);
+      }
+      return sum;
+    }, []);
+  });
+
+  return Object.assign({}, lintResult, {results});
+}
+
+/**
+ * Applies sourcemap to lint result if exists.
+ *
+ * @param{Object} lintResult - Result of StyleLint.
+ * @param{SourceMap} sourceMap - Raw source map object.
+ * @return {Object} Same as lintResult structure.
+ */
+function applySourcemap(lintResult, sourceMap) {
+  if (!sourceMap) {
+    return lintResult;
+  }
+  const sourceMapConsumer = new SourceMapConsumer(sourceMap);
+  const originalPositionFor = sourceMapConsumer.originalPositionFor.bind(sourceMapConsumer);
+  return _applySourcemap(lintResult, originalPositionFor);
+}
+
+module.exports = {
+  _applySourcemap,
+  applySourcemap
+};

--- a/test/sourcemap.spec.js
+++ b/test/sourcemap.spec.js
@@ -1,0 +1,64 @@
+import test from 'tape';
+import {applySourcemap, _applySourcemap} from '../src/sourcemap';
+
+test('when sourcemap is undefined, should return same Object', t => {
+  t.plan(1);
+  const result = {
+    results: [{
+      source: "path/to/fake/source",
+      warnings: []
+    }]
+  };
+
+  const applied = applySourcemap(result, undefined);
+  t.equal(result, applied, 'return same object')
+});
+
+test('should return applied lint result', t => {
+  t.plan(1);
+  const result = {
+    results: [{
+      source: "path/to/fake/source",
+      warnings: [
+        {line: 1, column: 1, text: 'foo'},
+        {line: 2, column: 2, text: 'foo'},
+        {line: 1, column: 3, text: 'foo'},
+        {line: 3, column: 2, text: 'foo'},
+      ]
+    }]
+  };
+
+  const originalPositionFor = pos => {
+    if (pos.line === 1) {
+      return {
+        source: 'path/to/real/source',
+        line: 2,
+        column: 3
+      }
+    } else {
+      return {
+        source: 'path/to/real/source2',
+        line: 20,
+        column: 30
+      }
+    }
+  };
+
+  const applied = _applySourcemap(result, originalPositionFor);
+  t.deepEqual(applied, {
+    results: [{
+      source: 'path/to/real/source',
+      warnings: [
+        {line: 2, column: 3, text: 'foo'},
+        {line: 2, column: 3, text: 'foo'},
+      ]
+    }, {
+      source: 'path/to/real/source2',
+      warnings: [
+        {line: 20, column: 30, text: 'foo'},
+        {line: 20, column: 30, text: 'foo'},
+      ]
+
+    }]
+  }, 'line, col, source is replaced')
+});


### PR DESCRIPTION
## Current behavior

`gulp-stylelint` doesn't support sourcemap.
So, if project has the following task, StyleLint output is
confusing.

``` javascript
// In gulpfile.js
var sourcemaps = require('gulp-sourcemaps');
gulp.src(paths)
  .pipe(sourcemaps.init())
  .pipe(someCompileCSS())
  .pipe(stylelint({
    reporters: [
      {formatter: 'string', console: true}
    ]
  }))
```

Output

```
foo.css
  23456:344 ✖  message   rule-name
```

gulp displays fake line, column and file name. Because, `someCompileCSS()` compiles css, and generate sourcemap, but `gulp-stylelint` doesn't support sourcemap. So, the line numbers are fake.
## Fixed behavior

I've added a support for gulp-sourcemaps. See https://github.com/floridoo/gulp-sourcemaps

`applySourcemap` method applies sourcemap to line, col and filename. And the method flattens warnings each file.
If files doesn't have sourcemap, the feature do nothing.

An example is in test code.
## Note
- StyleLint depends lodash already. So, the package doesn't become to fat by it depends lodash.
- `_applySourcemap` is exported for test. 
