### PR TITLE
Added error count in error output, like gulp-eslint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,8 +122,9 @@ module.exports = function gulpStylelint(options) {
       .then(passLintResultsThroughReporters)
       .then(lintResults => {
         process.nextTick(() => {
-          if (pluginOptions.failAfterError && lintResults.some(result => result.errored)) {
-            const errorMessage = 'Errors were found while linting code.';
+          const errorCount = lintResults.filter(result => result.errored).length;
+          if (pluginOptions.failAfterError && errorCount > 0) {
+            const errorMessage = `Failed with ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}`;
             this.emit('error', new PluginError(pluginName, errorMessage));
           }
           done();

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ module.exports = function gulpStylelint(options) {
       .then(passLintResultsThroughReporters)
       .then(lintResults => {
         process.nextTick(() => {
-          const errorCount = lintResults.filter(result => result.errored).length;
+          const errorCount = lintResults.reduce((sum, res) => sum + res.results[0].warnings.length, 0);
           if (pluginOptions.failAfterError && errorCount > 0) {
             const errorMessage = `Failed with ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}`;
             this.emit('error', new PluginError(pluginName, errorMessage));


### PR DESCRIPTION
I use gulp-stylelint with gulp-notify, and it would be really useful to see how many warning there are.

I updated the error message with the gulp-eslint one containing the error count.

Here it is in eslint: https://github.com/adametry/gulp-eslint/blob/master/index.js#L164