### PR TITLE
Replace formatter loading with stylelint.formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-util": "^3.0.7",
     "mkdirp": "^0.5.1",
     "promise": "^7.1.1",
-    "stylelint": "^7.6.0",
+    "stylelint": "^7.7.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,11 @@
  * @module gulp-stylelint
  */
 
-import {lint} from 'stylelint';
+import {formatters, lint} from 'stylelint';
 import {PluginError} from 'gulp-util';
 import through from 'through2';
 import Promise from 'promise';
 import deepExtend from 'deep-extend';
-import * as formatters from 'stylelint/dist/formatters';
 import reporterFactory from './reporter-factory';
 
 /**

--- a/src/reporter-factory.js
+++ b/src/reporter-factory.js
@@ -4,7 +4,7 @@
  */
 
 import gulpUtil from 'gulp-util';
-import * as formatters from 'stylelint/dist/formatters';
+import {formatters} from 'stylelint';
 import writer from './writer';
 
 /**


### PR DESCRIPTION
This will utilize `stylelint.formatters` added in `7.7.0` (and discussed in #57) instead of loading the formatters manually. I bumped the `stylelint` dependency as well.

Closes #57.