### PR TITLE
fix(plugin): resume stream

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ module.exports = function gulpStylelint(options) {
       });
   }
 
-  return through.obj(onFile, onStreamEnd);
+  return through.obj(onFile, onStreamEnd).resume();
 };
 
 /**

--- a/test/fixtures/invalid.css
+++ b/test/fixtures/invalid.css
@@ -1,0 +1,3 @@
+.foo {
+  color: #FFF;
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -38,6 +38,16 @@ test('should NOT emit an error when configuration is set', t => {
     .on('finish', () => t.pass('no error emitted'));
 });
 
+test('should emit an error when linter complains', t => {
+  t.plan(1);
+  gulp
+    .src(fixtures('invalid.css'))
+    .pipe(gulpStylelint({config: {rules: {
+      'color-hex-case': 'lower'
+    }}}))
+    .on('error', error => t.pass(`error ${error.code} has been emitted correctly`));
+});
+
 test('should expose an object with stylelint formatter functions', t => {
   t.plan(2);
   t.equal(typeof gulpStylelint.formatters, 'object', 'formatters property is an object');


### PR DESCRIPTION
Some people don't return streams in their gulp tasks or don't call gulp tasks at all, they also don't pipe to dest and the stream remains in paused state where the "end" event is never emitted. This change resumes the stream and allows the "end" event to be emitted.

Related to #51