### PR TITLE
Pass linter result down to stream

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,8 @@ module.exports = function gulpStylelint(options) {
           file.contents = Buffer.from(lintResult.output);
         }
 
+        file.stylelint = lintResult;
+
         done(null, file);
 
         return lintResult;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,6 +5,7 @@ const gulp = require('gulp');
 const gulpSourcemaps = require('gulp-sourcemaps');
 const path = require('path');
 const test = require('tape');
+const { Transform } = require('stream');
 
 const gulpStylelint = require('../src/index');
 
@@ -51,6 +52,22 @@ test('should emit an error when linter complains', t => {
       'color-hex-case': 'lower'
     }}}))
     .on('error', () => t.pass('error has been emitted correctly'));
+});
+
+test('should pass linter result down to stream', t => {
+  t.plan(1);
+  gulp
+    .src(fixtures('basic.css'))
+    .pipe(gulpStylelint({config: {rules: {
+      'color-hex-case': 'lower'
+    }}}))
+    .pipe(new Transform({
+      objectMode: true,
+      transform: (file, enc, cb) => {
+        t.equal(file.stylelint.errored, false, 'has no errors');
+        cb(null, file);
+      }
+    }));
 });
 
 test('should ignore file', t => {


### PR DESCRIPTION
Like [many](https://github.com/adametry/gulp-eslint/blob/master/index.js#L74) [other](https://github.com/panuhorsmalahti/gulp-tslint/blob/master/index.js#L105) [plugins](https://github.com/rogeriopvl/gulp-jsonlint/blob/master/index.js#L33) `gulp-stylelint` should pass lint results down to file stream so pipes can work with that data, it's not possible to implement [caching](https://github.com/olegskl/gulp-stylelint/issues/101) correctly without that.